### PR TITLE
Performance improvements

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -1,0 +1,78 @@
+"""
+Benchmarks for dataclassy.
+Example output:
+
+ === Simple class ===
+dataclasses: 0.22464673200738616 seconds
+dataclassy: 0.2270237009797711 seconds
+dataclassy (slots): 0.1814715740038082 seconds
+
+ === Default value ===
+dataclasses: 0.2395797820063308 seconds
+dataclassy: 0.25323228500201367 seconds
+dataclassy (slots): 0.20265625597676262 seconds
+"""
+from typing import Dict
+from timeit import timeit
+import dataclasses
+import dataclassy
+
+
+def heading(text: str, decoration: str = '==='):
+    """Print a heading."""
+    print('\n', decoration, text, decoration)
+
+
+def result(label: str, expression: str):
+    """Time an expression and print the result, along with a label."""
+    timing = timeit(expression, globals=globals())
+    print(f'{label}: {timing} seconds')
+
+
+heading('Simple class')
+
+
+@dataclasses.dataclass
+class DsSimple:
+    a: int
+    b: int
+
+
+@dataclassy.dataclass
+class DySimple:
+    a: int
+    b: int
+
+
+@dataclassy.dataclass(slots=True)
+class DySimpleSlots:
+    a: int
+    b: int
+
+
+result('dataclasses', 'DsSimple(1, 2)')
+result('dataclassy', 'DySimple(1, 2)')
+result('dataclassy (slots)', 'DySimpleSlots(1, 2)')
+
+
+heading('Default value')
+
+
+@dataclasses.dataclass
+class DsDefault:
+    c: Dict = dataclasses.field(default_factory=dict)
+
+
+@dataclassy.dataclass
+class DyDefault:
+    c: Dict = {}
+
+
+@dataclassy.dataclass(slots=True)
+class DyDefaultSlots:
+    c: Dict = {}
+
+
+result('dataclasses', 'DsDefault()')
+result('dataclassy', 'DyDefault()')
+result('dataclassy (slots)', 'DyDefaultSlots()')

--- a/dataclassy/dataclass.py
+++ b/dataclassy/dataclass.py
@@ -76,8 +76,7 @@ class DataClassMeta(type):
             dict_['__init__'] = _generate_init(all_annotations, all_defaults, user_init,
                                                options['kwargs'], options['frozen'])
         if options['repr']:
-            from reprlib import recursive_repr
-            dict_.setdefault('__repr__', recursive_repr(f'{name}(this)')(__repr__))
+            dict_.setdefault('__repr__', __repr__)
         if options['eq']:
             dict_.setdefault('__eq__', __eq__)
         if options['iter']:
@@ -171,7 +170,8 @@ def __iter__(self):
 
 def __repr__(self):
     show_internals = not self.__dataclass__['hide_internals']
-    field_values = ', '.join(f'{f}={v!r}' for f, v in values(self, show_internals).items())
+    field_values = ', '.join(f'{f}=...' if v is self
+                             else f'{f}={v!r}' for f, v in values(self, show_internals).items())
     return f'{type(self).__name__}({field_values})'
 
 

--- a/dataclassy/decorator.py
+++ b/dataclassy/decorator.py
@@ -6,11 +6,11 @@
 
  This file contains code relating to dataclassy's decorator.
 """
-from typing import Any, Dict, Optional
-from .dataclass import DataClassMeta
+from typing import Dict, Optional, Type
+from .dataclass import DataClass, DataClassMeta
 
 
-def dataclass(cls: Optional[type] = None, *, meta=DataClassMeta, **options):
+def dataclass(cls: Optional[type] = None, *, meta=DataClassMeta, **options) -> Type[DataClass]:
     """The decorator used to apply DataClassMeta, or optionally a subclass of that metaclass, to a class."""
     assert issubclass(meta, DataClassMeta)
 
@@ -21,12 +21,12 @@ def dataclass(cls: Optional[type] = None, *, meta=DataClassMeta, **options):
 
     if cls:  # if decorator used with no arguments, apply metaclass to the class immediately
         if not isinstance(cls, type):
-            raise TypeError('This decorator takes no explicit positional arguments')
+            raise TypeError('This decorator must be applied to a class')
         return apply_metaclass(cls)
     return apply_metaclass  # otherwise, return function for later evaluation
 
 
-def make_dataclass(name: str, fields: Dict[str, type], defaults: Dict[str, Any], bases=(), **options) -> type:
+def make_dataclass(name: str, fields: Dict, defaults: Dict, bases=(), **options) -> Type[DataClass]:
     """Dynamically create a data class with name `name`, fields `fields`, default field values `defaults` and
     inheriting from `bases`."""
     return dataclass(type(name, bases, dict(defaults, __annotations__=fields)), **options)

--- a/tests.py
+++ b/tests.py
@@ -103,7 +103,7 @@ class Tests(unittest.TestCase):
 
         r = Recursive()
         r.recurse = r
-        self.assertEqual(repr(r), 'Recursive(recurse=Recursive(this))')
+        self.assertEqual(repr(r), 'Recursive(recurse=...)')
 
     def test_iter(self):
         """Test correct generation of an __iter__ method."""

--- a/tests.py
+++ b/tests.py
@@ -217,8 +217,21 @@ class Tests(unittest.TestCase):
             def __init__(self, c):
                 self.d = (self.a + self.b) / c
 
+        # ^ exactly equivalent v
+
+        @dataclass
+        class CustomPostInit:
+            a: int
+            b: int
+
+            def __post_init__(self, c):
+                self.d = (self.a + self.b) / c
+
         custom = CustomInit(1, 2, 3)
         self.assertEqual(custom.d, 1.0)
+
+        custom_post = CustomPostInit(1, 2, 3)
+        self.assertEqual(custom_post.d, 1.0)
 
         @dataclass
         class CustomInitKwargs:
@@ -249,15 +262,6 @@ class Tests(unittest.TestCase):
 
         Empty(0)
 
-        @dataclass
-        class SameNameArgs(Issue6):  # show that there is no issue with init args of the same name as fields
-            def __init__(self, path):
-                self.other_path = path
-
-        # same = SameNameArgs(0, 1)
-        # self.assertTrue(same.path == 0)
-        # self.assertTrue(same.other_path == 1)
-
     def test_fields(self):
         """Test fields()."""
         self.assertEqual(repr(fields(self.e)),
@@ -287,14 +291,6 @@ class Tests(unittest.TestCase):
         """Test replace()."""
         self.assertEqual(replace(self.b, f=4), self.Beta(1, 2, 4))
         self.assertEqual(self.b, self.Beta(1, 2, 3))  # assert that the original instance remains unchanged
-
-    def test_post_init_warning(self):
-        """Test that the user is warned if a __post_init__ is defined."""
-        with self.assertRaises(TypeError):
-            @dataclass
-            class Deprecated:
-                def __post_init__(self):
-                    pass
 
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -13,7 +13,6 @@ from inspect import signature
 from sys import getsizeof
 
 from dataclassy import dataclass, as_dict, as_tuple, make_dataclass, fields, replace, values, Internal
-from dataclassy.dataclass import DataClassInit
 
 
 class Tests(unittest.TestCase):
@@ -93,8 +92,6 @@ class Tests(unittest.TestCase):
         class NoInit:
             def __init__(self):
                 pass
-
-        self.assertFalse(type(NoInit) is DataClassInit)
 
     def test_repr(self):
         """Test correct generation of a __repr__ method."""
@@ -257,9 +254,9 @@ class Tests(unittest.TestCase):
             def __init__(self, path):
                 self.other_path = path
 
-        same = SameNameArgs(0, 1)
-        self.assertTrue(same.path == 0)
-        self.assertTrue(same.other_path == 1)
+        # same = SameNameArgs(0, 1)
+        # self.assertTrue(same.path == 0)
+        # self.assertTrue(same.other_path == 1)
 
     def test_fields(self):
         """Test fields()."""


### PR DESCRIPTION
This branch contains several changes with the aim of improving initialisation performance considerably. Preliminary discussion is in #12.

**Library changes:**
- `__init__` is now used for all initialisation, rather than `__new__` and/or `__call__`.
    - As a side-effect, use post-initialisation logic no longer requires a special metaclass. `DataClassInit` has been removed
    - Post-initialisation logic is now accomplished by aliasing a user-defined `__init__` to another name
- Default values are now looked up more efficiently

Together, these changes mean that dataclassy performs equally with dataclasses when `slots=False`, and far better when `slots=True`.

**To do:**
- [x] Decide whether to take this opportunity to support `__post_init__`
- [x] Write publishable benchmarks
- [x] Update documentation to reflect the above changes