### PR TITLE
Don't check against isinstance result when checking for hashable properties

### DIFF
--- a/dataclassy/dataclass.py
+++ b/dataclassy/dataclass.py
@@ -162,7 +162,7 @@ def __lt__(self: DataClass, other: DataClass):
 
 def __hash__(self):
     # currently not ideal since gives no warning if a field expected to be hashable is not
-    return hash((type(self), *(v for v in self.__tuple__ if v is isinstance(v, Hashable))))
+    return hash((type(self), *(v for v in self.__tuple__ if isinstance(v, Hashable))))
 
 
 def __iter__(self):


### PR DESCRIPTION

Signed-off-by: Kurt Greaves <kurt.greaves@zepben.com>