### PR TITLE
Enable typing per PEP-561

### DIFF
--- a/dataclassy/__init__.py
+++ b/dataclassy/__init__.py
@@ -11,19 +11,10 @@ from .functions import fields, values, as_dict, as_tuple, replace
 # aliases intended for migration from dataclasses
 asdict, astuple = as_dict, as_tuple
 
+# for the benefit of mypy --strict
 __all__ = (
-    'dataclass',
-    'make_dataclass',
-
-    'DataClass',
-    'Internal',
-
-    'fields',
-    'values',
-    'as_dict',
-    'as_tuple',
-    'replace',
-
-    'asdict',
-    'astuple',
+    'dataclass', 'make_dataclass',
+    'DataClass', 'Internal',
+    'fields', 'values', 'as_dict', 'as_tuple', 'replace',
+    'asdict', 'astuple',
 )

--- a/dataclassy/__init__.py
+++ b/dataclassy/__init__.py
@@ -10,3 +10,20 @@ from .functions import fields, values, as_dict, as_tuple, replace
 
 # aliases intended for migration from dataclasses
 asdict, astuple = as_dict, as_tuple
+
+__all__ = (
+    'dataclass',
+    'make_dataclass',
+
+    'DataClass',
+    'Internal',
+
+    'fields',
+    'values',
+    'as_dict',
+    'as_tuple',
+    'replace',
+
+    'asdict',
+    'astuple',
+)

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ setup(
     long_description_content_type='text/markdown',
 
     packages=['dataclassy'],
+    package_data={
+        'dataclassy': ['py.typed'],
+    },
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',


### PR DESCRIPTION
## Description of changes
All that needs to be done is to add a "py.typed" file to the package, since adequate type annotations exist in all of the dataclassy code.

## Testing
I installed the package locally and checked the following program with `mypy --strict` and it failed in the same way that dataclasses fails when the mypy dataclasses plugin is disabled.

```python
from dataclassy import dataclass

@dataclass(slots=True)
class Foo:
    a: int
    b: str

x = Foo(1, 'abc')
```

Gives the following error:

```
dc.py:8: error: Too many arguments for "Foo"
Found 1 error in 1 file (checked 1 source file)
```

Which means that:
1. mypy recognises that dataclassy supports types (hooray!)
2. recognizes the types of the decorators (hooray!)
3. does not yet understand how the decorators create new types, but only a mypy plugin can solve that (more work to do!)