### PR TITLE
add another multiple inheritance test for member functions

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -488,17 +488,24 @@ class Tests(unittest.TestCase):
         self.assertEqual(child.e, 5)
 
     def test_multiple_inheritance_members(self):
+        """Test multiple-inheritance for member functions."""
         @dataclass
         class A:
-            def f(self): return 1
+            def f(self):
+                return 1
+
         class B(A):
-            def f(self): return 2
+            def f(self):
+                return 2
+
         class C(A):
             pass
+
         class D(C, B):
             pass
 
         self.assertIs(D.f, B.f)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -487,6 +487,18 @@ class Tests(unittest.TestCase):
         self.assertEqual(child.d, 4)
         self.assertEqual(child.e, 5)
 
+    def test_multiple_inheritance_members(self):
+        @dataclass
+        class A:
+            def f(self): return 1
+        class B(A):
+            def f(self): return 2
+        class C(A):
+            pass
+        class D(C, B):
+            pass
+
+        self.assertIs(D.f, B.f)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This test is for when a member is defined in the second base class but not directly in the first, when both inherit from the same grandparent class.  It still fails post #30.

I can take a stab at a solution if you like.