### PR TITLE
Decorating classes which derive from ABC throws an exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,15 @@ Although dataclassy's API is similar to dataclasses', [compatibility with it is 
 
 dataclassy has several important differences from dataclasses, mainly reflective of its minimalistic style and implementation. These differences are enumerated below and fully expanded on in the next section.
 
-|                                 |dataclasses                                 |dataclassy                              |
-|---------------------------------|:-------------------------------------------|:---------------------------------------|
-|*init-only variables*            |fields with type `InitVar`                  |arguments to `__post_init__`            |
-|*class variables*                |fields with type `ClassVar`                 |fields without type annotation          |
-|*mutable defaults*               |`a: Dict = field(default_factory=dict)`     |`a: Dict = {}`                          |
-|*dynamic defaults*               |`b: MyClass = field(default_factory=MyClass)`|`b: MyClass = factory(MyClass)`        |
-|*field excluded from `repr`*     |`c: int = field(repr=False)`                |`Internal` type wrapper or `_name`      |
-|*"late init" field*              |`d: int = field(init=False)`                |`d: int = None`                         |
+|                                                                                                            | dataclasses                                                | dataclassy                                                               |
+|------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|--------------------------------------------------------------------------|
+| *init-only variables*                                                                                      | fields with type `InitVar`                                 | arguments to `__post_init__`                                             |
+| *class variables*                                                                                          | fields with type `ClassVar`                                | fields without type annotation                                           |
+| *mutable defaults*                                                                                         | `a: Dict = field(default_factory=dict)`                    | `a: Dict = {}`                                                           |
+| *dynamic defaults*                                                                                         | `b: MyClass = field(default_factory=MyClass)`              | `b: MyClass = factory(MyClass)`                                          |
+| *field excluded from `repr`*                                                                               | `c: int = field(repr=False)`                               | `Internal` type wrapper or `_name`                                       |
+| *"late init" field*                                                                                        | `d: int = field(init=False)`                               | `d: int = None`                                                          |
+| *on classes using a metaclass other than `type`, e.g. [ABC](https://docs.python.org/3/library/abc.html)* | <pre> @dataclass <br/> class Foo(ABC): <br/>    ... </pre> | <pre> @dataclass <br/> class Foo(metaclass=ABCMeta): <br/>    ... </pre> |
 
 There are a couple of minor differences, too:
 

--- a/README.md
+++ b/README.md
@@ -94,15 +94,15 @@ Although dataclassy's API is similar to dataclasses', [compatibility with it is 
 
 dataclassy has several important differences from dataclasses, mainly reflective of its minimalistic style and implementation. These differences are enumerated below and fully expanded on in the next section.
 
-|                                                                                                            | dataclasses                                                | dataclassy                                                               |
-|------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|--------------------------------------------------------------------------|
-| *init-only variables*                                                                                      | fields with type `InitVar`                                 | arguments to `__post_init__`                                             |
-| *class variables*                                                                                          | fields with type `ClassVar`                                | fields without type annotation                                           |
-| *mutable defaults*                                                                                         | `a: Dict = field(default_factory=dict)`                    | `a: Dict = {}`                                                           |
-| *dynamic defaults*                                                                                         | `b: MyClass = field(default_factory=MyClass)`              | `b: MyClass = factory(MyClass)`                                          |
-| *field excluded from `repr`*                                                                               | `c: int = field(repr=False)`                               | `Internal` type wrapper or `_name`                                       |
-| *"late init" field*                                                                                        | `d: int = field(init=False)`                               | `d: int = None`                                                          |
-| *on classes using a metaclass other than `type`, e.g. [ABC](https://docs.python.org/3/library/abc.html)* | <pre> @dataclass <br/> class Foo(ABC): <br/>    ... </pre> | <pre> @dataclass <br/> class Foo(metaclass=ABCMeta): <br/>    ... </pre> |
+|                                 |dataclasses                                 |dataclassy                              |
+|---------------------------------|:-------------------------------------------|:---------------------------------------|
+|*init-only variables*            |fields with type `InitVar`                  |arguments to `__post_init__`            |
+|*class variables*                |fields with type `ClassVar`                 |fields without type annotation          |
+|*mutable defaults*               |`a: Dict = field(default_factory=dict)`     |`a: Dict = {}`                          |
+|*dynamic defaults*               |`b: MyClass = field(default_factory=MyClass)`|`b: MyClass = factory(MyClass)`        |
+|*field excluded from `repr`*     |`c: int = field(repr=False)`                |`Internal` type wrapper or `_name`      |
+|*"late init" field*              |`d: int = field(init=False)`                |`d: int = None`                         |
+|*abstract data class*            |`class Foo(ABC):`                           |`class Foo(metaclass=ABCMeta):`         |
 
 There are a couple of minor differences, too:
 


### PR DESCRIPTION
```python
In [1]: from dataclassy import dataclass

In [2]: from abc import ABC, ABCMeta

In [3]: @dataclass
   ...: class AbstractBase(ABC):
   ...:     pass
   ...: 
---------------------------------------------------------------------------
...
TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases

In [4]: @dataclass
   ...: class AbstractBase(metaclass=ABCMeta):
   ...:     pass
   ...: 

In [5]: AbstractBase()
Out[5]: AbstractBase()
```

This isn't a bug, but I think the solution is probably going to be non-obvious to most of your users, who will likely not have played with metaclasses before (this was me before today). As such, I thought I'd mention it explicitly in the docs.

Two things:
1. Your table raw formatting isn't very pretty anymore. Sorry. I at least ran it thought the markdown tables generator to get the spacing even.
2. I'm unsure of the best wording for the first column, so please edit if you believe it is unclear or inaccurate. You may also think this belongs somewhere else entirely, which is fine by me.