### PR TITLE
Add cmp_internals + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ CustomDefault()  # CustomDefault(m=<__main__.MyClass object at 0x7f8b156fc7d0>)
 
 ## API
 ### Decorator
-#### `@dataclass(init=True, repr=True, eq=True, iter=False, frozen=False, kwargs=False, slots=False, hide_internals=True, meta=DataClassMeta)`
+#### `@dataclass(init=True, repr=True, eq=True, iter=False, frozen=False, kwargs=False, slots=False, hide_internals=True, cmp_internals=True, meta=DataClassMeta)`
 The decorator used to signify that a class definition should become a data class. The decorator returns a new data class with generated methods as detailed below. If the class already defines a particular method, it will not be replaced with a generated one.
 
 Without arguments, its behaviour is, superficially, almost identical to its equivalent in the built-in module. However, dataclassy's decorator only needs to be applied once, and all subclasses will become data classes with the same parameters. The decorator can still be reapplied to subclasses in order to change parameters.
@@ -240,7 +240,10 @@ If true, add [`**kwargs`](https://docs.python.org/3.3/glossary.html#term-paramet
 If true, generate a [`__slots__`](https://docs.python.org/3/reference/datamodel.html#slots) attribute for the class. This reduces the memory footprint of instances and attribute lookup overhead. However, `__slots__` come with a few [restrictions](https://docs.python.org/3/reference/datamodel.html#notes-on-using-slots) (for example, multiple inheritance becomes tricky) that you should be aware of.
 
 ##### `hide_internals`
-If true (the default), [internal fields](#internal) are not included in the generated `__repr__`.
+If true (the default), [internal fields](#internal) are *not* included in the generated `__repr__`.
+
+##### `cmp_internals`
+If true (the default), [internals fields](#internal) *are* included when computing [equality](#eq), [ordering](#order), and [iteration](#iter).
 
 ##### `meta`
 Set this parameter to use a metaclass other than dataclassy's own. This metaclass must subclass [`dataclassy.dataclass.DataClassMeta`](dataclassy/dataclass.py).

--- a/dataclassy/dataclass.py
+++ b/dataclassy/dataclass.py
@@ -60,7 +60,7 @@ def factory(producer: Callable[[], Factory.Produces]) -> Factory.Produces:
 class DataClassMeta(type):
     """The metaclass that implements data class behaviour."""
     DEFAULT_OPTIONS = dict(init=True, repr=True, eq=True, iter=False, frozen=False, order=False, unsafe_hash=False,
-                           kwargs=False, slots=False, hide_internals=True)
+                           kwargs=False, slots=False, hide_internals=True, cmp_internals=True)
 
     def __new__(mcs, name, bases, dict_, **kwargs):
         """Create a new data class."""
@@ -144,7 +144,8 @@ class DataClassMeta(type):
 
         # determine a static expression for an instance's fields as a tuple, then evaluate this to create a property
         # allowing efficient representation for internal methods
-        tuple_expr = ', '.join((*(f'self.{f}' for f in fields(cls)), ''))  # '' ensures closing comma
+        internals = cls.__dataclass__['cmp_internals']
+        tuple_expr = ', '.join((*(f'self.{f}' for f in fields(cls, internals)), ''))  # '' ensures closing comma
         cls.__tuple__ = property(eval(f'lambda self: ({tuple_expr})'))
 
 

--- a/dataclassy/decorator.py
+++ b/dataclassy/decorator.py
@@ -25,6 +25,7 @@ def dataclass(cls: Optional[type] = None, *, meta=DataClassMeta, **options) -> T
     :key order: Generate comparison methods other than __eq__
     :key unsafe_hash: Force generation of __hash__
     :key hide_internals: Hide internal methods in __repr__
+    :key cmp_internals: Use internal fields to generate __tuple__, used in eq, cmp, and iter
     :return: The newly created data class
     """
     assert issubclass(meta, DataClassMeta)

--- a/tests.py
+++ b/tests.py
@@ -55,13 +55,23 @@ class Tests(unittest.TestCase):
 
         NT = namedtuple('NT', 'x y z')
 
-        @dataclass  # a complex (nested) class
+        @dataclass(cmp_internals=False)  # a complex (nested) class
         class Epsilon:
             g: Tuple[NT]
             h: List['Epsilon']
             _i: int = 0
 
-        self.Alpha, self.Beta, self.Gamma, self.Delta, self.Epsilon = Alpha, Beta, Gamma, Delta, Epsilon
+        @dataclass(iter=True, order=True)
+        class Zeta:
+            a: int
+            _b: int
+
+        @dataclass(iter=True, order=True, cmp_internals=False)
+        class Eta:
+            a: int
+            _b: int
+
+        self.Alpha, self.Beta, self.Gamma, self.Delta, self.Epsilon, self.Zeta, self.Eta = Alpha, Beta, Gamma, Delta, Epsilon, Zeta, Eta
         self.NT = NT
         self.b = self.Beta(1, 2, 3)
         self.e = self.Epsilon((self.NT(1, 2, 3)), [self.Epsilon(4, 5, 6)])
@@ -171,12 +181,24 @@ class Tests(unittest.TestCase):
         self.assertEqual(b, 2)
         self.assertEqual(f, [2, 3])
 
+        # test with and without cmp_internals
+        iterable = self.Zeta(0, 1)
+        a, _b = iterable
+        self.assertEqual(a, 0)
+        self.assertEqual(_b, 1)
+        iterable = self.Eta(0, 1)
+        with self.assertRaises(ValueError):
+            a, _b = iterable
+
     def test_eq(self):
         """Test correct generation of an __eq__ method."""
         self.assertEqual(self.b, self.b)
         unequal_b = self.Beta(10, 20, 30)
         self.assertNotEqual(self.b, unequal_b)
         self.assertNotEqual(self.b, [0])  # test comparisons with non-dataclasses
+        # test with and without cmp_internals
+        self.assertNotEqual(self.Zeta(0, 0), self.Zeta(0, 1))
+        self.assertEqual(self.Eta(0, 0), self.Eta(0, 1))
 
     def test_order(self):
         """Test correct generation of comparison methods."""
@@ -202,6 +224,10 @@ class Tests(unittest.TestCase):
 
         with self.assertRaises(TypeError):  # test absence of total_ordering if eq is false
             PartiallyOrderable() >= PartiallyOrderable()
+
+        # test with and without cmp_internals
+        self.assertLess(self.Zeta(0, 0), self.Zeta(0, 1))
+        self.assertFalse(self.Eta(0, 0) < self.Eta(0, 1))
 
     def test_hashable(self):
         """Test correct generation of a __hash__ method."""


### PR DESCRIPTION
This is an implementation of the first idea to address #53. There are two things I don't like about it:
1. Even though the new option is called `cmp_internals`, it also affects iteration, since `eq`, `order`, and `iter` all make use of `__tuple__` under the hood. I think a sensible interface would be to also have `iter_internals` to control `iter` behavior separately, but that involves either storing two versions of `__tuple__` when the two options don't agree or filtering a single version containing internals on the fly as necessary, both of which have overhead. Thoughts would be appreciated.
2. This is a breaking change (you'll notice I had to set `cmp_internals=False` to get all the tests using `Epsilon` to work). The easy fix is just to make it `False` by default, but as I argue in #53, I believe it should be `True` by default in order to agree with `dataclasses`, not to mention your own docs :grin:. Again, thoughts would be appreciated.